### PR TITLE
To avoid diffs, change to `vpc_security_group_ids`

### DIFF
--- a/terraform/app-servers.tf
+++ b/terraform/app-servers.tf
@@ -4,7 +4,7 @@ resource "aws_instance" "app" {
   ami = "${lookup(var.amis, var.region)}"
   instance_type = "t2.micro"
   subnet_id = "${aws_subnet.private.id}"
-  security_groups = ["${aws_security_group.default.id}"]
+  vpc_security_group_ids = ["${aws_security_group.default.id}"]
   key_name = "${aws_key_pair.deployer.key_name}"
   source_dest_check = false
   user_data = "${file(\"cloud-config/app.yml\")}"


### PR DESCRIPTION
I noticed that using `security_groups` instead of `vpc_security_group_ids` in the EC2s, causes diffs at every `terraform apply`.

```
-/+ aws_instance.app.0
[...]
    security_groups.#:            "0" => "1" (forces new resource)
    security_groups.2027228756:   "" => "sg-d95494bf" (forces new resource)
[...]
-/+ aws_instance.app.1
    security_groups.#:            "0" => "1" (forces new resource)
    security_groups.2027228756:   "" => "sg-d95494bf" (forces new resource)
[...]

-/+ aws_instance.nat
[...]
    security_groups.#:            "0" => "2" (forces new resource)
    security_groups.2027228756:   "" => "sg-d95494bf" (forces new resource)
    security_groups.4096171602:   "" => "sg-845898e2" (forces new resource)
[...]
```

Changing the `security_groups` to `vpc_security_group_ids`, no more diffs:



```
17:11 $ tf plan
Refreshing Terraform state in-memory prior to plan...
The refreshed state will be used to calculate this plan, but will not be
persisted to local or remote state storage.

aws_key_pair.deployer: Refreshing state... (ID: deployer-key)
aws_vpc.default: Refreshing state... (ID: vpc-819ceae5)
aws_internet_gateway.default: Refreshing state... (ID: igw-9955bbfd)
aws_security_group.web: Refreshing state... (ID: sg-a95a9acf)
aws_security_group.default: Refreshing state... (ID: sg-d95494bf)
aws_security_group.nat: Refreshing state... (ID: sg-845898e2)
aws_route_table.public: Refreshing state... (ID: rtb-8299a6e6)
aws_subnet.public: Refreshing state... (ID: subnet-334d6a6b)
aws_instance.nat: Refreshing state... (ID: i-037734af6c23c7821)
aws_route_table_association.public: Refreshing state... (ID: rtbassoc-8c1ba1eb)
aws_route_table.private: Refreshing state... (ID: rtb-a581bec1)
aws_subnet.private: Refreshing state... (ID: subnet-e82700b0)
aws_instance.app.0: Refreshing state... (ID: i-0b958ec00319d37f8)
aws_instance.app.1: Refreshing state... (ID: i-0d001d48d0c3daa15)
aws_route_table_association.private: Refreshing state... (ID: rtbassoc-66cd4801)
aws_elb.app: Refreshing state... (ID: example-elb)
No changes. Infrastructure is up-to-date.

This means that Terraform did not detect any differences between your
configuration and real physical resources that exist. As a result, Terraform
doesn't need to do anything.
```